### PR TITLE
refactor: renaming PostProcessing to Manager & moving managers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,11 +5,11 @@ import Camera from "./Core/Camera"
 import Renderer from "./Core/Renderer"
 import { AnimationLoop } from "./Core/AnimationLoop"
 import { AssetManager } from "./Assets/AssetManager"
-import PostProcessing from "./Core/PostProcessing" 
+import PostProcessingManager from "./Core/Managers/PostProcessingManager.js" 
 import Debug from "./Utils/Debug"
-import Ocean from './Assets/Ocean.js';
+import Ocean from './Assets/Ocean.js'
 import SkyManager from './Assets/SkyManager.js'
-import EventsManager from './Utils/EventsManager';
+import EventsManager from './Core/Managers/EventsManager'
 
 let myAppInstance = null
 
@@ -45,7 +45,7 @@ export default class App extends EventEmitter {
 
         this.assetManager = null
 
-        this.postProcessing = null
+        this.postProcessingManager = null
         this.enablePostProcessing = true
 
         this.cube = null
@@ -53,14 +53,13 @@ export default class App extends EventEmitter {
         this.museumMixer = null
         this.playMuseumAnimation = false
 
-        this.startOverlay = null;
-        this.startButton = null;
-        this.endOverlay = null;
-        this.experienceStarted = false;
-        this.experienceEnded = false;
+        this.startOverlay = null
+        this.startButton = null
+        this.endOverlay = null
+        this.experienceStarted = false
+        this.experienceEnded = false
 
-        this.popins = {};
-        this.eventsManager = null;
+        this.eventsManager = null
 
         this.init()
     }
@@ -77,69 +76,68 @@ export default class App extends EventEmitter {
         this.assetsLoadCompleteHandlerBound = this.assetsLoadCompleteHandler.bind(this)
         this.assetManager.on('ready', this.assetsLoadCompleteHandlerBound)
         this.assetManager.load()
-        this.setupUI();
 
-        // Initialiser le gestionnaire de popins APRÈS setupUI() pour éviter les conflits
-        this.eventsManager = new EventsManager();
+        this.eventsManager = new EventsManager()
 
-        // Exemple d'écoute des événements du gestionnaire de popins
         this.eventsManager.on('popinShown', (popinId) => {
-            console.log(`Popin "${popinId}" affichée`);
-        });
+            console.log(`Popin "${popinId}" affichée`)
+        })
+
+        this.setupUI()
     }
 
     setupUI() {
-        this.startOverlay = document.querySelector('.start-overlay');
-        this.startButton = document.querySelector('.start-button');
-        this.endOverlay = document.querySelector('.end-overlay');
+        this.startOverlay = document.querySelector('.start-overlay')
+        this.startButton = document.querySelector('.start-button')
+        this.endOverlay = document.querySelector('.end-overlay')
         
-        console.log('End overlay element:', this.endOverlay);
+        console.log('End overlay element:', this.endOverlay)
         
-        this.startButton.addEventListener('click', () => this.startExperience());
+        this.startButton.addEventListener('click', () => this.startExperience())
     }
 
     startExperience() {
-        if (this.experienceStarted) return;
+        if (this.experienceStarted) return
         
-        this.experienceStarted = true;
+        this.experienceStarted = true
         
-        this.startOverlay.classList.add('hidden');
+        this.startOverlay.classList.add('hidden')
         
-        this.canvas.style.opacity = '1';
-        this.camera.switchCamera();
+        this.canvas.style.opacity = '1'
+        this.camera.switchCamera()
 
         if (this.museumMixer) {
-            this.museumMixer.stopAllAction();
+            this.museumMixer.stopAllAction()
             
-            const museum = this.assetManager.getItem('Museum');
+            const museum = this.assetManager.getItem('Museum')
             museum.animations.forEach((clip) => {
-                this.museumMixer.clipAction(clip).reset().play();
-            });
+                this.museumMixer.clipAction(clip).reset().play()
+            })
         }
     
         setTimeout(() => {
             this.playMuseumAnimation = !this.playMuseumAnimation
-        }, 1500);
+        }, 1500)
     }
 
     endExperience() {
-        if (this.experienceEnded) return;
-        this.experienceEnded = true;
+        if (this.experienceEnded) return
+        this.experienceEnded = true
         
-        this.endOverlay.classList.remove('hidden');
+        this.endOverlay.classList.remove('hidden')
         
-        void this.endOverlay.offsetWidth;
+        void this.endOverlay.offsetWidth
         
-        this.canvas.style.opacity = '0';
+        this.canvas.style.opacity = '0'
         
         setTimeout(() => {
-            this.endOverlay.classList.add('visible');
-        }, 100);
+            this.endOverlay.classList.add('visible')
+        }, 100)
     }
 
     assetsLoadCompleteHandler() {
         this.initScene()
-        this.postProcessing = new PostProcessing(this.renderer.instance, this.scene, this.camera.mainCamera)
+        this.postProcessingManager = new PostProcessingManager(this.renderer.instance, this.scene, this.camera.mainCamera)
         this.animationLoop.start()
         this.debug = new Debug()
         this.debug.showAnimationClipLine(this.assetManager.getItem('Museum'), 'animation_0')
@@ -148,7 +146,7 @@ export default class App extends EventEmitter {
     initScene() {
         this.scene = new Scene()
         this.skyManager = new SkyManager(this.scene, this.renderer.instance)
-        this.ocean = new Ocean(this.scene, this.renderer.instance);
+        this.ocean = new Ocean(this.scene, this.renderer.instance)
 
         const ambientLight = new AmbientLight(0xffffff, 1)
         this.scene.add(ambientLight)
@@ -166,9 +164,9 @@ export default class App extends EventEmitter {
 
         this.museumMixer = new AnimationMixer(museum.scene)
         museum.animations.forEach((clip) => {
-            const action = this.museumMixer.clipAction(clip);
-            action.paused = true;
-            action.play();
+            const action = this.museumMixer.clipAction(clip)
+            action.paused = true
+            action.play()
         })
 
         fishes.scene.position.set(0, 1, 14)
@@ -191,11 +189,11 @@ export default class App extends EventEmitter {
     }
 
     update(time) {
-        this.fishesMixer.update(time.delta);
+        this.fishesMixer.update(time.delta)
         
         if (this.experienceStarted && this.museumMixer) {
             if(this.playMuseumAnimation){
-            this.museumMixer.update(time.delta);
+            this.museumMixer.update(time.delta)
         }
 
         }
@@ -205,7 +203,7 @@ export default class App extends EventEmitter {
         this.camera.applyLookAroundOffset()
 
         if (this.enablePostProcessing) {
-            this.postProcessing.render(this.camera.mainCamera)
+            this.postProcessingManager.render(this.camera.mainCamera)
         } else {
             this.renderer.instance.render(this.scene, this.camera.mainCamera)
         }
@@ -214,20 +212,16 @@ export default class App extends EventEmitter {
     }
 
     destroy() {
-        if (this.startButton) {
-            this.startButton.removeEventListener('click', this.startExperience);
-        }
+        this.startButton.removeEventListener('click', this.startExperience)
 
-        if (this.eventsManager) {
-            this.eventsManager.destroy();
-            this.eventsManager = null;
-        }
+        this.eventsManager.destroy()
+        this.eventsManager = null
 
         this.scene.remove(this.cube)
         this.cube.destroy()
         this.cube = null
 
-        this.postProcessing = null  
+        this.postProcessingManager = null  
 
         this.gui = null
         
@@ -248,9 +242,12 @@ export default class App extends EventEmitter {
         this.assetManager.destroy()
         this.assetManager = null
 
-        this.startOverlay = null;
-        this.startButton = null;
-        this.endOverlay = null;
+        this.popinManager.destroy()
+        this.popinManager = null
+
+        this.startOverlay = null
+        this.startButton = null
+        this.endOverlay = null
 
         this.canvas = null
 

--- a/src/Core/Camera.js
+++ b/src/Core/Camera.js
@@ -2,7 +2,7 @@ import { PerspectiveCamera, Vector3, Euler, Quaternion } from "three";
 import EventEmitter from "../Utils/EventEmitter";
 import App from "../App";
 import { OrbitControls } from "three/examples/jsm/Addons.js";
-import CameraManager from "./CameraManager";
+import CameraManager from "./Managers/CameraManager";
 
 export default class Camera extends EventEmitter {
     constructor() {

--- a/src/Core/Managers/CameraManager.js
+++ b/src/Core/Managers/CameraManager.js
@@ -1,7 +1,7 @@
 import * as core from '@theatre/core'
 // import studio from '@theatre/studio'
 
-import state from '../../static/cameraAnimations/aquarium.json'
+import state from '../../../static/cameraAnimations/aquarium.json'
 
 export default class CameraManager {
     constructor(camera) {

--- a/src/Core/Managers/EventsManager.js
+++ b/src/Core/Managers/EventsManager.js
@@ -1,4 +1,4 @@
-import EventEmitter from './EventEmitter';
+import EventEmitter from '../../Utils/EventEmitter';
 
 /**
  * Classe gérant les alertes du système via window.alert()

--- a/src/Core/Managers/PostProcessingManager.js
+++ b/src/Core/Managers/PostProcessingManager.js
@@ -3,11 +3,11 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
 import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js'
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
 import { RenderPixelatedPass } from 'three/addons/postprocessing/RenderPixelatedPass.js';
-import { FisheyeShader } from '../Shaders/FisheyeShader.js'
+import { FisheyeShader } from '../../Shaders/FisheyeShader.js'
 import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
-import App from '../App.js'
+import App from '../../App.js'
 
-export default class PostProcessing {
+export default class PostProcessingManager {
     constructor(renderer, scene, camera) {
         this.composer = new EffectComposer(renderer)
         this.scene = scene

--- a/src/Utils/Debug.js
+++ b/src/Utils/Debug.js
@@ -53,21 +53,24 @@ export default class Debug extends EventEmitter {
         if (event.key === 'p') {
             this.app.eventsManager.displayAlert("Ceci est une popin d'information",'information');
         }
+        if (event.key === 'g') {
+            this.app.postProcessingManager.triggerGlitch();
+        }
     })
 
     const postProcessingFolder = this.gui.addFolder('Post Processing')
 
     postProcessingFolder.add(this.app, 'enablePostProcessing', true).name('Enable Post Processing')
-    postProcessingFolder.add(this.app.postProcessing.fisheyePass, 'enabled', true).name('Enable Fisheye Pass')
-    postProcessingFolder.add(this.app.postProcessing.renderPixelatedPass, 'enabled', true).name('Enable Pixelated Pass')
-    postProcessingFolder.add(this.app.postProcessing.fxaaPass, 'enabled', true).name('Enable Fxaa Pass')
-    postProcessingFolder.add(this.app.postProcessing.renderPixelatedPass, 'normalEdgeStrength', 0, 1).name('Normal Edge Strength')
-    postProcessingFolder.add(this.app.postProcessing.renderPixelatedPass, 'depthEdgeStrength', 0, 1).name('Depth Edge Strength')
-    postProcessingFolder.add( this.app.postProcessing, 'pixelSize', 1, 50 ).onChange( () => {
-        this.app.postProcessing.renderPixelatedPass.setPixelSize( this.app.postProcessing.pixelSize );
+    postProcessingFolder.add(this.app.postProcessingManager.fisheyePass, 'enabled', true).name('Enable Fisheye Pass')
+    postProcessingFolder.add(this.app.postProcessingManager.renderPixelatedPass, 'enabled', true).name('Enable Pixelated Pass')
+    postProcessingFolder.add(this.app.postProcessingManager.fxaaPass, 'enabled', true).name('Enable Fxaa Pass')
+    postProcessingFolder.add(this.app.postProcessingManager.renderPixelatedPass, 'normalEdgeStrength', 0, 1).name('Normal Edge Strength')
+    postProcessingFolder.add(this.app.postProcessingManager.renderPixelatedPass, 'depthEdgeStrength', 0, 1).name('Depth Edge Strength')
+    postProcessingFolder.add( this.app.postProcessingManager, 'pixelSize', 1, 50 ).onChange( () => {
+        this.app.postProcessingManager.renderPixelatedPass.setPixelSize( this.app.postProcessingManager.pixelSize );
     } );        
-    postProcessingFolder.add(this.app.postProcessing, 'triggerGlitch').name('Trigger Glitch')
-    postProcessingFolder.add(this.app.postProcessing, 'triggerBigGlitch').name('Trigger Big glitch')
+    postProcessingFolder.add(this.app.postProcessingManager, 'triggerGlitch').name('Trigger Glitch')
+    postProcessingFolder.add(this.app.postProcessingManager, 'triggerBigGlitch').name('Trigger Big glitch')
     postProcessingFolder.open()
 
     const skyFolder = this.gui.addFolder('Sky')
@@ -87,15 +90,15 @@ export default class Debug extends EventEmitter {
 
     skyFolder.close()
 
-    const popinsFolder = this.gui.addFolder('Popins');
+    const eventsFolder = this.gui.addFolder('Events');
     
-    popinsFolder.add({
+    eventsFolder.add({
         showInfoPopin: () => {
            this.app.eventsManager.displayAlert("Ceci est une popin d'information",'information');
         }
     }, 'showInfoPopin').name('Afficher Info Popin');
     
-    popinsFolder.add({
+    eventsFolder.add({
         showWarningPopin: () => {
             this.app.eventsManager.displayAlert("Ceci est une popin de warning", 'Attention');
         }


### PR DESCRIPTION
Moving managers from ./Core to ./Core/Managers to keep files tree clean.
**Might break** non pushed work **on paths** for imports.